### PR TITLE
feat: Expose user image in card config

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,13 +54,13 @@ For manual YAML configuration, use these options:
 | title                | string  | Card title                                          | Plant name   |
 | display_mode         | string  | `full` or `compact`                                 | `full`       |
 | battery_threshold    | number  | Battery level (%) at which icon appears (0-100)     | `30`         |
+| preferred_image      | string  | `user` or `default`                                 | `user`       |
 | show_scientific_name | boolean | Show light sensor                                   | `true`       |
 | state_color_battery  | boolean | Expose battery state in color of battery icon       | `true`       |
 | state_color_icon     | boolean | Expose sensor state in color of sensor icons        | `true`       |
 | state_color_plant    | string  | `image`, `name`, or `disabled`                      | `image`      |
 | state_color_sensor   | boolean | Expose sensor state in color of sensor bars         | `true`       |
 | sensor               | boolean | Array of sensor information                         | See sensors  |
-
 
 ### Sensors
 Sensors is a YAML array that set the order of sensors and whether they are enabled. Each entry consists of a type (`light`, `moisture`, `temperature`, `salinity`, or `nutrients`) and its state `isEnabled`.
@@ -81,6 +81,7 @@ device_id: 12345abc67890def123456
 title: My Monstera
 display_mode: compact
 battery_threshold: 30
+preferred_image: user
 show_scientific_name: true
 state_color_battery: true
 state_color_icon: true

--- a/dist/fyta-plant-card.js
+++ b/dist/fyta-plant-card.js
@@ -375,7 +375,7 @@ class FytaPlantCard extends LitElement {
     this._otherEntityIds = {
       [SensorTypes.FERTILIZED_LAST]: '',
       [SensorTypes.FERTILIZED_NEXT]: '',
-      [SensorTypes.PLANT_IMAGE]: '',
+      [SensorTypes.PLANT_IMAGE_DEFAULT]: '',
       [SensorTypes.PLANT_IMAGE_USER]: '',
       [SensorTypes.SCIENTIFIC_NAME]: '',
     };

--- a/dist/fyta-plant-card.js
+++ b/dist/fyta-plant-card.js
@@ -84,6 +84,10 @@ const SensorTypes = {
   TEMPERATURE_STATE: 'temperature',
 };
 
+const TranslationKeys = {
+  PLANT_IMAGE_USER: 'plant_image_user',
+};
+
 const DEFAULT_CONFIG = {
   battery_threshold: 30,
   device_id: '',
@@ -533,13 +537,13 @@ class FytaPlantCard extends LitElement {
       const userImageEntityId = this._otherEntityIds[SensorTypes.PLANT_IMAGE_USER];
 
       if (userImageEntityId && hass.states[userImageEntityId]?.attributes.entity_picture) {
-        return hass.states[userImageEntityId]?.attributes.entity_picture;
+        return hass.states[userImageEntityId]?.attributes.entity_picture || '';
       }
     }
 
     const defaultImageEntityId = this._otherEntityIds[SensorTypes.PLANT_IMAGE_DEFAULT];
     if (defaultImageEntityId && hass.states[defaultImageEntityId]?.attributes.entity_picture) {
-      return hass.states[defaultImageEntityId]?.attributes.entity_picture;
+      return hass.states[defaultImageEntityId]?.attributes.entity_picture || '';
     }
 
     return '';
@@ -550,11 +554,14 @@ class FytaPlantCard extends LitElement {
     if (!stateEntity) return;
 
     if (id.startsWith('image.')) {
-      if (id.endsWith('plant_image_user')) {
+      const entity = hass.entities[id];
+      if (!entity) return;
+
+      if (entity.translation_key === TranslationKeys.PLANT_IMAGE_USER) {
         this._otherEntityIds[SensorTypes.PLANT_IMAGE_USER] = stateEntity.entity_id;
-      } else {
-        this._otherEntityIds[SensorTypes.PLANT_IMAGE_DEFAULT] = stateEntity.entity_id;
+        return;
       }
+      this._otherEntityIds[SensorTypes.PLANT_IMAGE_DEFAULT] = stateEntity.entity_id;
       return;
     }
 

--- a/dist/fyta-plant-card.js
+++ b/dist/fyta-plant-card.js
@@ -1571,6 +1571,9 @@ export class FytaPlantCardEditor extends LitElement {
       .item .item-label {
         flex-grow: 1;
       }
+      .sensors {
+        margin-bottom: 12px;
+      }
     `;
   }
 

--- a/dist/fyta-plant-card.js
+++ b/dist/fyta-plant-card.js
@@ -569,7 +569,7 @@ class FytaPlantCard extends LitElement {
     if (!hassEntity) return;
 
     if (id.startsWith('image.')) {
-      if (entity.translation_key === TranslationKeys.PLANT_IMAGE_USER) {
+      if (hassEntity.translation_key === TranslationKeys.PLANT_IMAGE_USER) {
         this._otherEntityIds[SensorTypes.PLANT_IMAGE_USER] = hassState.entity_id;
         return;
       }

--- a/hacs.json
+++ b/hacs.json
@@ -1,5 +1,5 @@
 {
-    "name": "FYTA Plant Card",
-    "filename": "fyta-plant-card.js",
-    "homeassistant": "2025.6.0"
-  }
+  "name": "FYTA Plant Card",
+  "filename": "fyta-plant-card.js",
+  "homeassistant": "2025.6.0"
+}

--- a/hacs.json
+++ b/hacs.json
@@ -1,5 +1,5 @@
 {
-    "name": "Fyta Plant Card",
+    "name": "FYTA Plant Card",
     "filename": "fyta-plant-card.js",
-    "homeassistant": "2025.1.0"
+    "homeassistant": "2025.6.0"
   }


### PR DESCRIPTION
An update to the FYTA integration is making the plant user image available:
https://github.com/home-assistant/core/pull/140934

This PR adds a setting to the FYTA plant card that allows the user to choose the preferred image to be shown on the card. If set to the user image, the card will show the user image of a plant if it is available.