### PR TITLE
fix: Set max value to 100%

### DIFF
--- a/dist/fyta-plant-card.js
+++ b/dist/fyta-plant-card.js
@@ -969,7 +969,7 @@ class FytaPlantCard extends LitElement {
     let percentage = null;
     if (sensorState !== null && sensorSettings.min !== null && sensorSettings.max != null) {
       const calculatedPercentage = (sensorState - sensorSettings.min) / (sensorSettings.max - sensorSettings.min) * 100;
-      percentage = Math.max(0, Math.min(100100, calculatedPercentage));
+      percentage = Math.max(0, Math.min(100, calculatedPercentage));
     }
 
     switch (statusState) {


### PR DESCRIPTION
This went undetected in the rewrite. The max percentage of the meter bar needs to be limited to 100%.