### PR TITLE
feat: Add option for sensor value decimals

### DIFF
--- a/dist/fyta-plant-card.js
+++ b/dist/fyta-plant-card.js
@@ -111,7 +111,7 @@ const TranslationKeys = {
 
 const DEFAULT_CONFIG = {
   battery_threshold: 30,
-  decimals: false,
+  decimals: DecimalsState.UNTOUCHED,
   device_id: '',
   display_mode: DisplayMode.FULL,
   sensors: [
@@ -522,6 +522,11 @@ class FytaPlantCard extends LitElement {
     return parts[0];
   }
 
+  _formatDecimals(value, decimals = 0) {
+    const numberValue = Number(value);
+    return isNaN(numberValue) ? '' : numberValue.toFixed(decimals);
+  }
+
   _getPlantImageSrc(hass) {
     if (this.config.preferred_image === PreferredPlantImage.USER) {
       const userImageEntityId = this._otherEntityIds[SensorTypes.PLANT_IMAGE_USER];
@@ -538,11 +543,6 @@ class FytaPlantCard extends LitElement {
 
     return '';
   };
-
-  _formatNumberToString(value, decimals = 0) {
-    const numberValue = Number(value);
-    return isNaN(numberValue) ? '' : numberValue.toFixed(decimals);
-  }
 
   _handleEntity(id, hass) {
     const hassState = hass.states[id];
@@ -1112,7 +1112,7 @@ class FytaPlantCard extends LitElement {
       const sensorSettings = SENSOR_SETTINGS[sensorType];
       const sensorEntityId = this._measurementEntityIds[sensorType];
       const sensorValue = hass.states[sensorEntityId].state;
-      const formattedSensorValue = this.config.decimals === false ? sensorValue : this._formatNumberToString(sensorValue, this.config.decimals);
+      const formattedSensorValue = this.config.decimals === false ? sensorValue : this._formatDecimals(sensorValue, this.config.decimals);
 
       // Get proper units for display and tooltip
       const unitOfMeasurement = hass.states[sensorEntityId].attributes.unit_of_measurement || '';


### PR DESCRIPTION
The FYTA Public API provides integer values only. The entities in the FYTA integration default to one decimal. This leads to a pseudo-precision in the display of the sensor data. 24°C will always be incorrectly displayed as 24.0°C. On the plant card, this also leads to unnecessary noise. In the limited space available, we show zeroes in the sensor readings that do not add any additional information, as they will always be the same.

While the FYTA Public API might change in the future and adjusting this in the options for each entity is not a solution to me. Thus I propse to add an option to the plant card. It defaults to not changing the sensor readings and behaving as before but enables the user to choose to set the decimals of the readings to their liking. The screenshots still show an option to go with two decimals which was implemented for testing but has since been removed.

<img width="1011" alt="Bildschirmfoto 2025-06-20 um 11 52 07" src="https://github.com/user-attachments/assets/db9e6f5c-d7e4-47d5-9612-5f534695f4f9" />
<img width="996" alt="Bildschirmfoto 2025-06-20 um 11 52 16" src="https://github.com/user-attachments/assets/550fa6e3-3933-4f7d-83d2-486daf7df7fe" />
<img width="1001" alt="Bildschirmfoto 2025-06-20 um 11 52 29" src="https://github.com/user-attachments/assets/1b7fd387-af26-4a46-8d17-4990b14e1d70" />
